### PR TITLE
Emit event when reaching end of event stream transaction

### DIFF
--- a/src/AppCoreNet.EventStore.Abstractions/EventTransactionCommittingEvent.cs
+++ b/src/AppCoreNet.EventStore.Abstractions/EventTransactionCommittingEvent.cs
@@ -1,0 +1,11 @@
+namespace AppCoreNet.EventStore
+{
+    /// <summary>
+    /// An event which is emitted before the transaction processing the event queue is committed.
+    /// This allows listeners to ensure any buffered work is completed before the transaction is committed.
+    /// </summary>
+    [EventType(nameof(EventTransactionCommittingEvent))]
+    public class EventTransactionCommittingEvent
+    {
+    }
+}

--- a/src/AppCoreNet.EventStore/Subscriptions/SubscriptionService.cs
+++ b/src/AppCoreNet.EventStore/Subscriptions/SubscriptionService.cs
@@ -141,10 +141,12 @@ public sealed class SubscriptionService : BackgroundService
 
                 try
                 {
-                    await listener.HandleAsync(
-                        watchResult.SubscriptionId,
-                        new EventEnvelope(new EventTransactionCommittingEvent()),
-                        cancellationToken);
+                    await listener
+                        .HandleAsync(
+                            watchResult.SubscriptionId,
+                            new EventEnvelope(new EventTransactionCommittingEvent()),
+                            cancellationToken)
+                        .ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This allows subscribers to buffer data across events and ensure those buffers are flushed before the transaction is committed.