### PR TITLE
Wrap writing events in a lock to avoid race condition

### DIFF
--- a/src/AppCoreNet.EventStore.SqlServer/SqlServerEventStore.cs
+++ b/src/AppCoreNet.EventStore.SqlServer/SqlServerEventStore.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the MIT license.
+// Licensed under the MIT license.
 // Copyright (c) The AppCore .NET project.
 
 using System;
@@ -62,6 +62,7 @@ public sealed class SqlServerEventStore<TDbContext> : IEventStore
             StreamId = streamId,
             ExpectedPosition = state.Value,
             Events = events,
+            LockResource = _options.ApplicationName + "-WriteEvents",
         };
 
         Model.WriteEventsResult result =


### PR DESCRIPTION
If multiple threads, or multiple instance of the application attempt to write events to the event store at the same time, it can cause some events to be skipped. For example:

| Thread | Action |
| ---|---|
|Writer 1|Starts Transaction|
|Writer 1|Writes Event and updates the EventStream table with the new ID|
|Writer 2|Starts Transaction|
|Writer 2|Writes Event and updates the EventStream table with the new ID<br>(this will be higher than the ID that Writer 1 wrote)|
|Writer 2|Commits Transaction|
|Reader|Reads Event committed by Writer 2|
|Reader|Updates EventSubscription with processed ID|
|Writer 1|Commits Transaction|

The event from Writer 1 will never be processed as its ID is lower than the one that was already processed from Writer 2.

Therefore, we need to ensure that the events are committed in the same order as the IDs are allocated. We cannot perform this locking on the .NET side as there may be multiple instances of the application.