### PR TITLE
Only release lock when watching subscriptions if it was actually acquired

### DIFF
--- a/src/AppCoreNet.EventStore.SqlServer/Subscriptions/WatchSubscriptionsStoredProcedure.cs
+++ b/src/AppCoreNet.EventStore.SqlServer/Subscriptions/WatchSubscriptionsStoredProcedure.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under the MIT license.
+// Licensed under the MIT license.
 // Copyright (c) The AppCore .NET project.
 
 using System;
@@ -97,9 +97,9 @@ internal sealed class WatchSubscriptionsStoredProcedure : SqlStoredProcedure<Mod
                                 IF @{nameof(Timeout)} <= 0 BREAK;
                             END
                         END
-                    END
 
-                    EXEC sp_releaseapplock @Resource = @{nameof(LockResource)}
+                        EXEC sp_releaseapplock @Resource = @{nameof(LockResource)}
+                    END
 
                     SELECT
                         @Id AS [{nameof(Model.WatchSubscriptionsResult.Id)}],


### PR DESCRIPTION
The watch subscriptions stored procedure always attempts to release the lock regardless of whether it successfully acquired the lock or not.

This causes the procedure to fail sometimes when running multiple instances of the same application.